### PR TITLE
Fix active bank selection in ChatService

### DIFF
--- a/src/main/java/ru/michael/coco/chat/ChatService.java
+++ b/src/main/java/ru/michael/coco/chat/ChatService.java
@@ -31,7 +31,12 @@ public class ChatService {
 
     public Chat createChat(User student, Task task) {
         Group group = student.getGroups().stream().findFirst().orElseThrow(() -> new RuntimeException("User is not in a group"));
-        Bank activeBank = group.getBanks().stream().findFirst().orElseThrow(() -> new RuntimeException("Group has no active bank"));
+        Bank activeBank = group.getActiveBank();
+        if (activeBank == null) {
+            activeBank = group.getBanks().stream()
+                    .findFirst()
+                    .orElseThrow(() -> new RuntimeException("Group has no banks"));
+        }
 
         var chatters = new ArrayList<User>();
         chatters.add(activeBank.getGroup().getTeacher());


### PR DESCRIPTION
## Summary
- ensure ChatService uses group's active bank when creating chats

## Testing
- `mvn -q -DskipTests=false test` *(fails: mvn not found)*

------
https://chatgpt.com/codex/tasks/task_e_683fd7537080832f8fa3cccee3d7ad56